### PR TITLE
Path element can be not autoclosing

### DIFF
--- a/svg-to-mapael.php
+++ b/svg-to-mapael.php
@@ -108,7 +108,7 @@ if (count($_POST) > 0) {
 
     // Retrieve paths coordinates
     $elems = [];
-    preg_match_all('/<path(.*?)\/>/s', $svgContent, $matches);
+    preg_match_all('/<path(.*?)\/?>/s', $svgContent, $matches);
     $size = count($matches[0]);
 
     for ($i = 0; $i < $size; $i++) {


### PR DESCRIPTION
Path element can contain some other element, and thus the tag will not be "autoclosed" with `/>`. 

It allows to detect path like this:

``` xml
<path style="fill:#cee3f5;stroke:#6e6e6e;stroke-width:0.40000001" inkscape:connector-curvature="0" d="m 322.525,80.1875 0.9,0.8 0,0.3 -1,-0.7 z" id="FO">
    <namespace:desc>
        <namespace:name>Faroe Islands</namespace:name>
        <namespace:labelrank>6</namespace:labelrank>
        <namespace:country-abbrev>Faeroe Is.</namespace:country-abbrev>
        <namespace:subregion>Northern Europe</namespace:subregion>
        <namespace:region-wb>Europe &amp; Central Asia</namespace:region-wb>
        <namespace:iso-a3>FRO</namespace:iso-a3>
        <namespace:iso-a2>FO</namespace:iso-a2>
        <namespace:woe-id>23424816</namespace:woe-id>
        <namespace:continent>Europe</namespace:continent>
        <namespace:hc-middle-x>0.48</namespace:hc-middle-x>
        <namespace:hc-middle-y>0.54</namespace:hc-middle-y>
        <namespace:hc-key>fo</namespace:hc-key>
        <namespace:hc-a2>FO</namespace:hc-a2>
    </namespace:desc>
</path>
```
